### PR TITLE
Remove leaderboard button from welcome modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,9 +278,6 @@
                 <button class="welcome-button start-button" onclick="startGameFromWelcome()">
                     🤿 Comenzar Juego
                 </button>
-                <button class="welcome-button leaderboard-button" onclick="showLeaderboardFromWelcome()">
-                    📊 Ver Leaderboard
-                </button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
The "View leaderboard" button was present in both the welcome modal and the main game screen. This change removes the button from the welcome modal to avoid redundancy, as requested. The button on the main game screen remains untouched.